### PR TITLE
Movement Update

### DIFF
--- a/GodotTest/Scenes/TileMap.tscn
+++ b/GodotTest/Scenes/TileMap.tscn
@@ -7,7 +7,9 @@
 [node name="Level1" type="Node2D"]
 
 [node name="Player" parent="." instance=ExtResource( 1 )]
-position = Vector2( -200, -100 )
+position = Vector2( -200, -300 )
+xdecelA = 0.25
+xaccelA = 0.75
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 current = true

--- a/GodotTest/Scenes/mainGame.gd
+++ b/GodotTest/Scenes/mainGame.gd
@@ -1,15 +1,18 @@
 extends KinematicBody2D
 
 export(float) var runSpeed = 20
-export(float) var xdecelGround = 1
-export(float) var xdecelAir = 0
-export(float) var xaccel = 2
+export(float) var xdecelG = 1
+export(float) var xaccelG = 2
+export(float) var xdecelA = .5
+export(float) var xaccelA = 1
 export(float) var velCap = 10
-export(float) var velAirReduction = 0.5
+
 var move = 0.0
 var velocity = Vector2()
+
 export(float) var jumpHeight = 40
 export(float) var jumpTime = 0.3
+
 export(bool) var canIdle = true
 export(bool) var canFall = true
 
@@ -20,82 +23,89 @@ func _physics_process(delta):
 	
 	#direction
 	if(velocity.x > 0):
-		$Sprite.flip_h= false
+		$Sprite.flip_h = false
 	if(velocity.x < 0):
-		$Sprite.flip_h= true	
-	print(move)
-
+		$Sprite.flip_h = true
+	
 	#velocity calculations
 	# -y is up, +y is down
-	velocity.x = move * runSpeed
 	var gravity = 2*jumpHeight/(jumpTime*jumpTime)
 	velocity.y += gravity*delta
 	velocity = move_and_slide(velocity, Vector2(0, -1))
-
+	
+	#------------------------------------------------------------------------------------------------------------------------
 	#horizontal acceleration/deceleration
+	#velocity multiplier
+	velocity.x = move * runSpeed
+	#max speed
 	if(abs(move) >= velCap):
 		if(sign(move) == 1):
 			move = velCap
 		else:
 			move = -1*velCap
-		#deceleration on ground
-	if(sign(move) != 0 && is_on_floor() == true):
-		if(sign(move) == 1 && is_on_floor() == true):
-			move -= xdecelGround
-		else:
-			move += xdecelGround
-		#deceleration in air
-	if(sign(move) != 0 && is_on_floor() == false):
-		if(sign(move) == 1 && is_on_floor() == false):
-			move -= xdecelAir
-		else:
-			move += xdecelAir
-	#grounded movement
-	if(is_on_floor() == true):	
+	#prevents weird values that oscillate around 0
+	if(abs(move) < .5):
+		move=0
+			
+	#ground
+	if(is_on_floor() == true):
+		#deceleration ground
+		if(sign(move) != 0 ):
+			if(sign(move) == 1 ):
+				move -= xdecelG
+			else:
+				move += xdecelG		
+		#acceleration ground
+		#the sprite flips avoid the weird 1 frame direction issue with a direction change
 		if(Input.is_action_pressed("ui_right")):
-			move += xaccel-velAirReduction
+			move += xaccelG
+			if(velocity.x == 0):
+				$Sprite.flip_h = false
+		if(Input.is_action_pressed("ui_left")):
+			move -= xaccelG
+			if(velocity.x == 0):
+				$Sprite.flip_h = true
+				
+		#running animation
+		if(velocity.x != 0):
 			$AnimationPlayer.play("playerRun")
-		elif(Input.is_action_pressed("ui_left")):
-			move -= xaccel-velAirReduction
-			$AnimationPlayer.play("playerRun")
-		else:
-			velocity.x = 0
-			if(canIdle):
+		#idling animation
+		if(canIdle && velocity.x == 0):
 				$AnimationPlayer.play("playerIdle")
-		#air movement
-	if(is_on_floor() == false):
+				
+	#air
+	if(is_on_floor() == false):	
+		#deceleration air
+		if(sign(move) != 0):
+			if(sign(move) == 1):
+				move -= xdecelA
+			else:
+				move += xdecelA
+		#acceleration air
 		if(Input.is_action_pressed("ui_right")):
-			move += xaccel
-			$AnimationPlayer.play("playerRun")
-		elif(Input.is_action_pressed("ui_left")):
-			move -= xaccel
-			$AnimationPlayer.play("playerRun")
-		#else:
-			#velocity.x = 0
-		
+			move += xaccelA	
+		if(Input.is_action_pressed("ui_left")):
+			move -= xaccelA
+	#----------------------------------------------------------------------------------------------------------------------	
+	#other movement
 	if(Input.is_action_just_pressed("jump") && is_on_floor() == true):
 		$AnimationPlayer.play("playerJump")
 		velocity.y = -2*jumpHeight/jumpTime
-		
 	#wall jump
 	if(Input.is_action_just_pressed("jump") && is_on_floor() == false && is_on_wall() == true):
-		canFall = false
 		$AnimationPlayer.play("playerFlip")
 		velocity.y = -2*jumpHeight/jumpTime
-
 	#falling animation
-	if(is_on_floor() != true && velocity.y > 0 && canFall == true):
+	if(is_on_floor() != true && velocity.y > 0):
 		$AnimationPlayer.play("playerFalling")
-
-
-
-	#attack animations
-	if(Input.is_action_just_pressed("light attack") && canFall == true):
+	#----------------------------------------------------------------------------------------------------------------------
+	#attack animations (NOT COMPLETE)
+	if(Input.is_action_just_pressed("light attack")):
 		#animation runs on a different frame system than the script
 		#I set the canFall value in animation and it kept getting cancelled 
 		#do state checks in script, not animation, as they are faster here (constant vs variable update)
 		canFall = false
-		canIdle = false
+		#canIdle = false (PUT THIS IN ANIMATION PLAYER)
 		$AnimationPlayer.play("playerLightAttack")
 		print("Can idle is now ", canIdle)
 


### PR DESCRIPTION
### Fixed ground and air movement

For some reason if you change any of randy's variables to a non-zero value everything broke.

Details:
- Ground and air horizontal acceleration and deceleration cleaned up
- Fixed weird rapid fluctuations of the velocity value near 0
- Fixed sprite orientation issues on direction changes
- Fixed the running animation playing in midair when it's supposed to be the falling animation

- [ ] Need to add a velocity reduction after a wall jump to prevent catapulting in the same direction
- [ ] Short hops? Different jumps?
- [ ] Attack animation doesn't work

